### PR TITLE
Issue 2: Add ServerID to AppStart messages

### DIFF
--- a/go-ari-proxy.go
+++ b/go-ari-proxy.go
@@ -133,7 +133,7 @@ func PublishMessage(ariMessage string, producer chan []byte) {
 		// since we're starting a new application instance, create the proxy side
 		dialogID := ari.UUID()
 		Info.Println("New StasisStart found. Created new dialogID of ", dialogID)
-		as, err := json.Marshal(ari.AppStart{Application: info.Application, DialogID: dialogID})
+		as, err := json.Marshal(ari.AppStart{Application: info.Application, DialogID: dialogID, ServerID: message.ServerID})
 		producer <- as
 
 		// TODO: this sleep is required to allow the application time to spin up. In the future we likely want

--- a/go-ari-proxy.go
+++ b/go-ari-proxy.go
@@ -133,7 +133,7 @@ func PublishMessage(ariMessage string, producer chan []byte) {
 		// since we're starting a new application instance, create the proxy side
 		dialogID := ari.UUID()
 		Info.Println("New StasisStart found. Created new dialogID of ", dialogID)
-		as, err := json.Marshal(ari.AppStart{Application: info.Application, DialogID: dialogID, ServerID: message.ServerID})
+		as, err := json.Marshal(ari.AppStart{Application: info.Application, DialogID: dialogID, ServerID: config.ServerID})
 		producer <- as
 
 		// TODO: this sleep is required to allow the application time to spin up. In the future we likely want


### PR DESCRIPTION
This depends on a change on the go-ari-library side of things as well.
