### PR TITLE
Add a dockerfile to be able to create an image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+docs
+.git
+.gitignore
+.travis.yml
+config.json
+Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 go-ari-proxy
+config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang
+
+WORKDIR /go/src/
+
+RUN go get github.com/nvisibleinc/go-ari-library
+RUN go get golang.org/x/net/websocket
+RUN mkdir go-ari-proxy
+COPY . go-ari-proxy
+RUN go install go-ari-proxy
+
+CMD /go/bin/go-ari-proxy


### PR DESCRIPTION
Let me know your thoughts on this

The image doesn't deal with config files as I would expect, if this becomes an automated build, people will base their own docker images on this one and add the config file into the working directory.
